### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+tags
+*.swp
+.ruby-gemset
+.ruby-version

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -1,6 +1,6 @@
 require "hanami/events/adapter"
 require "hanami/events/base"
-require "hanami/events/listener"
+require "hanami/events/subscriber"
 require "hanami/events/version"
 
 module Hanami

--- a/lib/hanami/events/adapter/memory.rb
+++ b/lib/hanami/events/adapter/memory.rb
@@ -2,18 +2,20 @@ module Hanami
   module Events
     class Adapter
       class Memory
-        attr_reader :listeners
+        attr_reader :subscribers
 
         def initialize
-          @listeners = []
+          @subscribers = []
         end
 
-        def announce(event_name, payload)
-          @listeners.map { |listener| listener.call(event_name, payload) }
+        def broadcast(event_name, payload)
+          @subscribers.each do |subscriber|
+            subscriber.call(event_name, payload)
+          end
         end
 
-        def subscribe_pattern(event_name, &block)
-          @listeners << Listener.new(event_name, block)
+        def subscribe(event_name, &block)
+          @subscribers << Subscriber.new(event_name, block)
         end
       end
     end

--- a/lib/hanami/events/base.rb
+++ b/lib/hanami/events/base.rb
@@ -8,11 +8,11 @@ module Hanami
       end
 
       def broadcast(event, **payload)
-        adapter.announce(event, payload)
+        adapter.broadcast(event, payload)
       end
 
       def subscribe(event_name, &block)
-        adapter.subscribe_pattern(event_name, &block)
+        adapter.subscribe(event_name, &block)
       end
     end
   end

--- a/lib/hanami/events/subscriber.rb
+++ b/lib/hanami/events/subscriber.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Events
-    class Listener
+    class Subscriber
       def initialize(pattern, block)
         @pattern = pattern
         @block = block

--- a/spec/unit/hanami/events/adapter/memory_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_spec.rb
@@ -1,22 +1,26 @@
 RSpec.describe Hanami::Events::Adapter::Memory do
   let(:adapter) { described_class.new }
 
-  describe '#subscribe_pattern' do
+  describe '#subscribe' do
     it 'pushes listener to listener list' do
-      expect(adapter.listeners.count).to eq 0
-      adapter.subscribe_pattern('event.name') { |payload| payload }
-      expect(adapter.listeners.count).to eq 1
-      adapter.subscribe_pattern('event.name') { |payload| payload }
-      expect(adapter.listeners.count).to eq 2
+      expect(adapter.subscribers.count).to eq 0
+      adapter.subscribe('event.name') { |payload| payload }
+      expect(adapter.subscribers.count).to eq 1
+      adapter.subscribe('event.name') { |payload| payload }
+      expect(adapter.subscribers.count).to eq 2
     end
   end
 
-  describe '#announce' do
+  describe '#broadcast' do
+    let(:subscriber) { double('subscriber') }
+
     before do
-      adapter.subscribe_pattern('user.created') { |payload| payload }
+      adapter.subscribe('user.created') { |payload| subscriber.call(payload) }
     end
 
-    it { expect(adapter.announce('user.created', user_id: 1)).to eq [{ user_id: 1 }] }
-    it { expect(adapter.announce('user.deleted', user_id: 1)).to eq [nil] }
+    it 'calls #call method with payload on subscriber' do
+      expect(subscriber).to receive(:call).with(user_id: 1)
+      adapter.broadcast('user.created', user_id: 1)
+    end
   end
 end

--- a/spec/unit/hanami/events/subscriber_spec.rb
+++ b/spec/unit/hanami/events/subscriber_spec.rb
@@ -1,17 +1,17 @@
-RSpec.describe Hanami::Events::Listener do
+RSpec.describe Hanami::Events::Subscriber do
   let(:block) { proc { |payload| payload } }
-  let(:listener) { described_class.new('user.created', block) }
+  let(:subscriber) { described_class.new('user.created', block) }
 
   describe '#call' do
     context 'when event name matched' do
       it 'calls event block' do
-        expect(listener.call('user.created', user_id: 1)).to eq(user_id: 1)
+        expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1)
       end
     end
 
     context 'when event name not matched' do
       it 'calls nothing' do
-        expect(listener.call('user.deleted', user_id: 1)).to eq nil
+        expect(subscriber.call('user.deleted', user_id: 1)).to eq nil
       end
     end
   end

--- a/spec/unit/hanami/events_spec.rb
+++ b/spec/unit/hanami/events_spec.rb
@@ -12,17 +12,19 @@ RSpec.describe Hanami::Events do
       event.subscribe('user.created') { |payload| payload }
     end
 
-    it { expect(event.broadcast('user.created', user_id: 1)).to eq [{ user_id: 1 }] }
-    it { expect(event.broadcast('user.deleted', user_id: 1)).to eq [nil] }
+    it 'calls #broadcast on adapter' do
+      expect(event).to receive(:broadcast).with('user.created', user_id: 1)
+      event.broadcast('user.created', user_id: 1)
+    end
   end
 
   describe '#subscribe' do
-    it 'pushes listener to listener list' do
-      expect(event.adapter.listeners.count).to eq 0
+    it 'pushes subscriber to subscribers list' do
+      expect(event.adapter.subscribers.count).to eq 0
       event.subscribe('event.name') { |payload| payload }
-      expect(event.adapter.listeners.count).to eq 1
+      expect(event.adapter.subscribers.count).to eq 1
       event.subscribe('event.name') { |payload| payload }
-      expect(event.adapter.listeners.count).to eq 2
+      expect(event.adapter.subscribers.count).to eq 2
     end
   end
 end


### PR DESCRIPTION
1. Renamed `Listener` to `Subscriber`
2. Renamed `announce` to `broadcast` for adapters
3. Renamed `subscribe_pattern ` to `subscribe` for adapters
4. Changed `broadcast` for Memory adapter, switched from `map` to `each`. Should be good for performance.
5. Updated specs.
6. Refactored Redis adapter