### PR TITLE
[FIX #6] Implement subscribe_to method and Subscriber module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ events.broadcast('user.created', user_id: 1)
 # => { user_id: 1 }
 ```
 
+### Mixin
+There is a mixin that allows to subscribe to events from class.
+
+Example:
+```ruby
+$events = Hanami::Events.initialize(:memory)
+
+class WelcomeMailer
+  include Hanami::Events::Mixin
+
+  subscribe_to $events, 'user.created'
+
+  def call(payload)
+    # send email
+  end
+end
+```
+
+`$events.broadcast('user.created', user_i: 1)` would trigger `WelcomeMailer#call` with `user_id: 1` as a payload.
+
 #### Patterns
 * `*` - match all events
 * `user.*` - match all evensts started on `user.`

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -3,6 +3,7 @@ require "hanami/events/formatter"
 require "hanami/events/matcher"
 require "hanami/events/base"
 require "hanami/events/subscriber"
+require "hanami/events/mixin"
 require "hanami/events/version"
 
 # Events framework for Hanami

--- a/lib/hanami/events/mixin.rb
+++ b/lib/hanami/events/mixin.rb
@@ -1,0 +1,16 @@
+module Hanami
+  module Events
+    module Mixin
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def subscribe_to(event_bus, event_name)
+          klass = self
+          event_bus.subscribe(event_name) { |payload| klass.new.(payload) }
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/events/mixin_spec.rb
+++ b/spec/unit/hanami/events/mixin_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Hanami::Events::Mixin do
+  context 'when included into class' do
+    before do
+      EVENT_BUS = Hanami::Events.initialize(:memory_sync)
+
+      DummyHandler = Class.new do
+        include Hanami::Events::Mixin
+        subscribe_to EVENT_BUS, 'user.created'
+
+        def call(payload)
+          payload
+        end
+      end
+    end
+
+    it 'calls #call method on subscriber with payload' do
+      expect_any_instance_of(DummyHandler).to receive(:call).with(user_id: 1)
+      EVENT_BUS.broadcast('user.created', user_id: 1)
+    end
+  end
+end


### PR DESCRIPTION
```ruby
require 'hanami/events'

$event_bus =  Hanami::Events.initialize(:memory)

class Foo
  include Hanami::Events::Mixin

  subscribe_to $event_bus, 'user.created'

  def call(payload)
    puts payload
  end
end

$event_bus.broadcast('user.created', user_id: 1)
```

Global variable is just an example, probably in app it would be good to have container that would return event bus.

One problem I have with current implementation, that call method will not see logger passed during initialization of event bus.