### PR TITLE
[FIX #64] Introduce typed event attributes

### DIFF
--- a/hanami-events.gemspec
+++ b/hanami-events.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dry-container", "~> 0.6"
+  spec.add_dependency "dry-struct", "~> 0.3"
 
   spec.add_development_dependency "xml-simple"
   spec.add_development_dependency "redis"

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -1,3 +1,4 @@
+require "dry-struct"
 require "hanami/events/adapter"
 require "hanami/events/formatter"
 require "hanami/events/matcher"
@@ -7,6 +8,23 @@ require "hanami/events/mixin"
 require "hanami/events/version"
 
 module Hanami
+  module Types
+    include ::Dry::Types.module
+    UUID = String.constrained(format: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)
+  end
+
+  module Event
+    class Type < Dry::Struct
+      def self.event_name(name)
+        @event_name = name
+      end
+
+      def event_name
+        self.class.instance_variable_get(:@event_name)
+      end
+    end
+  end
+
   # Events framework for Hanami
   #
   # @since 0.1.0

--- a/lib/hanami/events/adapter/memory_async.rb
+++ b/lib/hanami/events/adapter/memory_async.rb
@@ -19,12 +19,11 @@ module Hanami
 
         # Brodcasts event to all subscribes
         #
-        # @param event [Symbol, String] the event name
-        # @param payload [Hash] the event data
+        # @param event
         #
         # @since 0.1.0
-        def broadcast(event_name, payload)
-          @event_queue << { id: SecureRandom.uuid, name: event_name, payload: payload }
+        def broadcast(event)
+          @event_queue << event
         end
 
         # Subscribes block for selected event
@@ -57,9 +56,7 @@ module Hanami
         def call_subscribers
           event = @event_queue.pop
 
-          @subscribers.each do |subscriber|
-            subscriber.call(event[:name], event[:payload])
-          end
+          @subscribers.each { |subscriber| subscriber.call(event) }
         end
       end
     end

--- a/lib/hanami/events/adapter/memory_sync.rb
+++ b/lib/hanami/events/adapter/memory_sync.rb
@@ -16,14 +16,11 @@ module Hanami
 
         # Brodcasts event to all subscribes
         #
-        # @param event [Symbol, String] the event name
-        # @param payload [Hash] the event data
+        # @param event
         #
         # @since 0.1.0
-        def broadcast(event_name, payload)
-          @subscribers.each do |subscriber|
-            subscriber.call(event_name, payload)
-          end
+        def broadcast(event)
+          @subscribers.each { |subscriber| subscriber.call(event) }
         end
 
         # Subscribes block for selected event

--- a/lib/hanami/events/base.rb
+++ b/lib/hanami/events/base.rb
@@ -18,8 +18,8 @@ module Hanami
       # @param payload [Hash] the event data
       #
       # @since 0.1.0
-      def broadcast(event, **payload)
-        adapter.broadcast(event, payload)
+      def broadcast(event)
+        adapter.broadcast(event)
       end
 
       # Calls subscribes for selected adapter

--- a/lib/hanami/events/formatter.rb
+++ b/lib/hanami/events/formatter.rb
@@ -19,7 +19,7 @@ module Hanami
         require_relative 'formatter/json'
         Json
       end
-      
+
       register(:xml) do
         require_relative 'formatter/xml'
         Xml

--- a/lib/hanami/events/subscriber.rb
+++ b/lib/hanami/events/subscriber.rb
@@ -17,8 +17,8 @@ module Hanami
           @logger = logger
         end
 
-        def call(payload)
-          instance_exec(payload, &@handler)
+        def call(event)
+          instance_exec(event, &@handler)
         end
       end
 
@@ -36,8 +36,8 @@ module Hanami
       # @since 0.1.0
       #
       # @api private
-      def call(event_name, payload)
-        @runner.(payload) if @pattern_matcher.match?(event_name)
+      def call(event)
+        @runner.(event) if @pattern_matcher.match?(event.event_name)
       end
 
       # Returns meta information for subscriber

--- a/spec/unit/hanami/events/adapter/memory_async_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_async_spec.rb
@@ -2,60 +2,63 @@ require 'hanami/events/adapter/memory_async'
 
 RSpec.describe Hanami::Events::Adapter::MemoryAsync do
   let(:adapter) { described_class.new }
+  let(:user_created) { double('user.created', event_name: 'user.created') }
+  let(:post_created) { double('post.created', event_name: 'post.created') }
+  let(:comment_created) { double('comment.created', event_name: 'comment.created') }
 
   describe '#subscribe' do
     it 'pushes subscriber to the list of subscribers' do
       expect {
-        adapter.subscribe('event.name') { |payload| payload }
+        adapter.subscribe('event.name') { |event| event }
       }.to change { adapter.subscribers.count }.by(1)
     end
   end
 
   describe '#broadcast' do
     before do
-      $user_array = []
-      adapter.subscribe('user.created') { |payload| $user_array << payload }
+      $user_events = []
+      adapter.subscribe('user.created') { |event| $user_events << event }
     end
 
-    it 'calls #call method with payload on subscriber' do
-      adapter.broadcast('user.created', user_id: 1)
+    it 'calls #call method with event object on subscriber' do
+      adapter.broadcast(user_created)
       sleep 0.01
-      expect($user_array).to eq [{ user_id: 1 }]
+      expect($user_events).to eq [user_created]
     end
 
     context 'when subscribe have heavy calculation ' do
       before do
         $post_array = []
 
-        adapter.subscribe('post.created') do |payload|
+        adapter.subscribe('post.created') do |event|
           sleep 1
-          $post_array << payload
+          $post_array << event
         end
       end
 
-      it 'calls #call method with payload on subscriber' do
-        adapter.broadcast('post.created', user_id: 1)
+      it 'calls #call method with event object on subscriber' do
+        adapter.broadcast(post_created)
         expect($post_array).to eq []
       end
     end
 
-    context 'when system have 2 subscribes ' do
+    context 'when system has 2 subscribes ' do
       before do
         $comment_array = []
 
-        adapter.subscribe('comment.created') do |payload|
-          $comment_array << payload
+        adapter.subscribe('comment.created') do |event|
+          $comment_array << event
         end
 
-        adapter.subscribe('comment.created') do |payload|
-          $comment_array << payload
+        adapter.subscribe('comment.created') do |event|
+          $comment_array << event
         end
       end
 
-      it 'calls #call method with payload on subscriber' do
-        adapter.broadcast('comment.created', user_id: 1)
+      it 'calls #call method with event object on subscriber' do
+        adapter.broadcast(comment_created)
         sleep 0.1
-        expect($comment_array).to eq [{ user_id: 1 }, { user_id: 1 }]
+        expect($comment_array).to eq [comment_created, comment_created]
       end
     end
   end

--- a/spec/unit/hanami/events/adapter/memory_sync_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_sync_spec.rb
@@ -2,23 +2,24 @@ require 'hanami/events/adapter/memory_sync'
 
 RSpec.describe Hanami::Events::Adapter::MemorySync do
   let(:adapter) { described_class.new }
+  let(:event) { double('user.created') }
 
   describe '#subscribe' do
     it 'pushes subscriber to the list of subscribers' do
       expect {
-        adapter.subscribe('event.name') { |payload| payload }
+        adapter.subscribe('event.name') { |event| event }
       }.to change { adapter.subscribers.count }.by(1)
     end
   end
 
   describe '#broadcast' do
     before do
-      adapter.subscribe('user.created') { |payload| subscriber.call(payload) }
+      adapter.subscribe('user.created') { |event| subscriber.call(event) }
     end
 
-    it 'calls #call method with payload on subscriber' do
-      expect(adapter.subscribers.first).to receive(:call).with('user.created', user_id: 1)
-      adapter.broadcast('user.created', user_id: 1)
+    it 'calls #call method with event object on subscriber' do
+      expect(adapter.subscribers.first).to receive(:call).with(event)
+      adapter.broadcast(event)
     end
   end
 end

--- a/spec/unit/hanami/events/base_spec.rb
+++ b/spec/unit/hanami/events/base_spec.rb
@@ -2,14 +2,15 @@ require 'hanami/events/adapter/memory_sync'
 
 RSpec.describe Hanami::Events::Base do
   let(:event_bus) { described_class.new(:memory_sync, {}) }
-  let(:handler) { Proc.new { |payload| payload } }
+  let(:event) { double('user_created') }
+  let(:handler) { Proc.new { |event| event } }
 
   describe 'broadcast' do
     it 'calls broadcast on adapter' do
       expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
-        receive(:broadcast).with('user.created', user_id: 1)
+        receive(:broadcast).with(event)
       )
-      event_bus.broadcast('user.created', user_id: 1)
+      event_bus.broadcast(event)
     end
   end
 

--- a/spec/unit/hanami/events/mixin_spec.rb
+++ b/spec/unit/hanami/events/mixin_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe Hanami::Events::Mixin do
   context 'when included into class' do
+    let(:user_created) { double('user.created', event_name: 'user.created') }
+
     before do
       EVENT_BUS = Hanami::Events.initialize(:memory_sync)
 
@@ -14,8 +16,8 @@ RSpec.describe Hanami::Events::Mixin do
     end
 
     it 'calls #call method on subscriber with payload' do
-      expect_any_instance_of(DummyHandler).to receive(:call).with(user_id: 1)
-      EVENT_BUS.broadcast('user.created', user_id: 1)
+      expect_any_instance_of(DummyHandler).to receive(:call).with(user_created)
+      EVENT_BUS.broadcast(user_created)
     end
   end
 end

--- a/spec/unit/hanami/events/subscriber_spec.rb
+++ b/spec/unit/hanami/events/subscriber_spec.rb
@@ -1,46 +1,49 @@
 require 'logger'
 
 RSpec.describe Hanami::Events::Subscriber do
-  let(:block) { proc { |payload| payload } }
+  let(:block) { proc { |event| event } }
+  let(:user_created) { double('user.created', event_name: 'user.created') }
+  let(:user_deleted) { double('user.deleted', event_name: 'user.deleted') }
+  let(:post_deleted) { double('post.deleted', event_name: 'post.deleted') }
   let(:subscriber) { described_class.new('user.created', block) }
 
   describe '#call' do
     context 'when event name matched' do
       it 'calls event block' do
-        expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1)
+        expect(subscriber.call(user_created)).to eq(user_created)
       end
     end
 
     context 'when event pattern match range' do
       let(:subscriber) { described_class.new('user.*', block) }
 
-      it { expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('user.deleted', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('post.deleted', post_id: 1)).to eq nil }
+      it { expect(subscriber.call(user_created)).to eq(user_created) }
+      it { expect(subscriber.call(user_deleted)).to eq(user_deleted) }
+      it { expect(subscriber.call(post_deleted)).to eq nil }
     end
 
     context 'when event pattern match all' do
       let(:subscriber) { described_class.new('*', block) }
 
-      it { expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('user.deleted', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('post.deleted', post_id: 1)).to eq(post_id: 1) }
+      it { expect(subscriber.call(user_created)).to eq(user_created) }
+      it { expect(subscriber.call(user_deleted)).to eq(user_deleted) }
+      it { expect(subscriber.call(post_deleted)).to eq(post_deleted)  }
     end
 
     context 'when event name not matched' do
       it 'calls nothing' do
-        expect(subscriber.call('user.deleted', user_id: 1)).to eq nil
+        expect(subscriber.call(user_deleted)).to eq nil
       end
     end
 
     context 'with logger' do
-      let(:block) { -> (_payload) { logger.info('in event') } }
+      let(:block) { -> (_event) { logger.info('in event') } }
       let(:logger) { Logger.new(StringIO.new) }
       let(:subscriber) { described_class.new('user.created', block, logger) }
 
       it 'calls logger' do
         expect(logger).to receive(:info).with('in event')
-        subscriber.call('user.created', user_id: 1)
+        subscriber.call(user_created)
       end
     end
 
@@ -48,7 +51,7 @@ RSpec.describe Hanami::Events::Subscriber do
       let(:block) { -> (_payload) { meta } }
       let(:subscriber) { described_class.new('user.created', block) }
 
-      it { expect { subscriber.call('user.created', user_id: 1) }.to raise_error(NameError) }
+      it { expect { subscriber.call(user_created) }.to raise_error(NameError) }
     end
   end
 

--- a/spec/unit/hanami/events_spec.rb
+++ b/spec/unit/hanami/events_spec.rb
@@ -1,36 +1,36 @@
 require 'support/fixtures'
 
 RSpec.describe Hanami::Events do
-  let(:event) { Hanami::Events.initialize(:memory_sync) }
+  let(:event_bus) { Hanami::Events.initialize(:memory_sync) }
 
-  it { expect(event).to be_a(Hanami::Events::Base) }
+  it { expect(event_bus).to be_a(Hanami::Events::Base) }
 
   describe '#adapter' do
-    it { expect(event.adapter).to be_a(Hanami::Events::Adapter::MemorySync) }
+    it { expect(event_bus.adapter).to be_a(Hanami::Events::Adapter::MemorySync) }
   end
 
   describe '#broadcast' do
-    let(:event_name) { 'user.created' }
+    let(:user_created) { double('user.created', event_name: 'user.created') }
 
     before do
-      event.subscribe(event_name) { |payload| payload }
+      event_bus.subscribe('user.created') { |event| event }
     end
 
     it 'calls #broadcast on adapter' do
-      expect(event.adapter).to receive(:broadcast).with('user.created', user_id: 1)
-      event.broadcast('user.created', user_id: 1)
+      expect(event_bus.adapter).to receive(:broadcast).with(user_created)
+      event_bus.broadcast(user_created)
     end
   end
 
   describe '#subscribed_events' do
     before do
-      event.subscribe('user.created') { |payload| payload }
-      event.subscribe('user.updated') { |payload| payload }
-      event.subscribe('user.deleted') { |payload| payload }
+      event_bus.subscribe('user.created') { |event| event }
+      event_bus.subscribe('user.updated') { |event| event }
+      event_bus.subscribe('user.deleted') { |event| event }
     end
 
     it 'returns list of all subscribed events' do
-      expect(event.subscribed_events).to eq([
+      expect(event_bus.subscribed_events).to eq([
         { name: 'user.created' },
         { name: 'user.updated' },
         { name: 'user.deleted' }
@@ -41,20 +41,20 @@ RSpec.describe Hanami::Events do
   describe '#subscribe' do
     it 'pushes subscriber to subscribers list' do
       expect {
-        event.subscribe('event.name') { |payload| payload }
-      }.to change { event.adapter.subscribers.count }.by(1)
+        event_bus.subscribe('event.name') { |event| event }
+      }.to change { event_bus.adapter.subscribers.count }.by(1)
     end
   end
 
   describe '#format' do
     before do
-      event.subscribe('user.created') { |payload| payload }
-      event.subscribe('user.updated') { |payload| payload }
-      event.subscribe('user.deleted') { |payload| payload }
+      event_bus.subscribe('user.created') { |payload| payload }
+      event_bus.subscribe('user.updated') { |payload| payload }
+      event_bus.subscribe('user.deleted') { |payload| payload }
     end
 
     it 'returns list of all subscribed events' do
-      expect(event.format(:json)).to eq "{\"events\":[{\"name\":\"user.created\"},{\"name\":\"user.updated\"},{\"name\":\"user.deleted\"}]}"
+      expect(event_bus.format(:json)).to eq "{\"events\":[{\"name\":\"user.created\"},{\"name\":\"user.updated\"},{\"name\":\"user.deleted\"}]}"
     end
   end
 


### PR DESCRIPTION
This PR adds typed attributes to events using [dry-struct](http://dry-rb.org/gems/dry-struct/).

Example of event definition:

```ruby
class UserCreated < Hanami::Event::Type
  event_name 'user.created'

  attribute :id, Hanami::Types::UUID
  attribute :name, Hanami::Types::String
end
```

We can instantiate and broadcast event now:

```ruby
user_created = UserCreated.new(id: "f1306260-6268-4a19-80dd-54ad1ac82039", name: "Sergii")
event_bus.broadcast(user_created)
```

Subscriber will receive object of `UserCreated` event:

```ruby
event_bus.subscribe('user.*') do |event|
  event # => <UserCreated id="f1306260-6268-4a19-80dd-54ad1ac82039" name="Sergii">
end
```

PS: @davydovanton I have a question regarding naming. I included `Event` to `Hanami::Event` namespace, I'm not sure if it's the best way. As well as use of `Hanami::Types` to define attribute types for an event. Probably we should discuss it too.