### PR TITLE
Allow passing extra args to subscribe in Events::Mixin

### DIFF
--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -14,6 +14,8 @@ module Hanami
   #
   # @see https://github.com/hanami/events
   module Events
+    EMPTY_HASH = {}.freeze
+
     class << self
       # Initialize event instance with selected adapter
       #

--- a/lib/hanami/events/adapter.rb
+++ b/lib/hanami/events/adapter.rb
@@ -8,6 +8,8 @@ module Hanami
     #
     # @api private
     class Adapter
+      EMPTY_HASH = {}.freeze
+
       extend Dry::Container::Mixin
 
       register(:memory_sync) do

--- a/lib/hanami/events/adapter/memory_async.rb
+++ b/lib/hanami/events/adapter/memory_async.rb
@@ -15,6 +15,7 @@ module Hanami
           @logger = logger
           @subscribers = []
           @event_queue = Queue.new
+          @thread_spawned = false
         end
 
         # Brodcasts event to all subscribes
@@ -33,7 +34,7 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, &block)
+        def subscribe(event_name, _kwargs = EMPTY_HASH, &block)
           @subscribers << Subscriber.new(event_name, block, @logger)
 
           return if thread_spawned?

--- a/lib/hanami/events/adapter/memory_sync.rb
+++ b/lib/hanami/events/adapter/memory_sync.rb
@@ -32,7 +32,7 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, &block)
+        def subscribe(event_name, _kwargs = EMPTY_HASH, &block)
           @subscribers << Subscriber.new(event_name, block, @logger)
         end
       end

--- a/lib/hanami/events/adapter/redis.rb
+++ b/lib/hanami/events/adapter/redis.rb
@@ -49,7 +49,7 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, &block) # rubocop:disable Metrics/MethodLength
+        def subscribe(event_name, _kwargs = EMPTY_HASH, &block) # rubocop:disable Metrics/MethodLength
           @subscribers << Subscriber.new(event_name, block, @logger)
 
           return if thread_spawned?

--- a/lib/hanami/events/base.rb
+++ b/lib/hanami/events/base.rb
@@ -28,11 +28,11 @@ module Hanami
       # @param callable_object [Proc] the object which will call istead block
       #
       # @since 0.1.0
-      def subscribe(event_name, callable_object = nil, &block)
+      def subscribe(event_name, callable_object = nil, **kwargs, &block)
         if callable_object && callable_object.respond_to?(:call)
-          adapter.subscribe(event_name, &->(*args) { callable_object.call(*args) })
+          adapter.subscribe(event_name, kwargs, &->(*rest) { callable_object.call(*rest) })
         else
-          adapter.subscribe(event_name, &block)
+          adapter.subscribe(event_name, kwargs, &block)
         end
       end
 

--- a/lib/hanami/events/mixin.rb
+++ b/lib/hanami/events/mixin.rb
@@ -25,9 +25,9 @@ module Hanami
 
       # Class interfaces
       module ClassMethods
-        def subscribe_to(event_bus, event_name)
+        def subscribe_to(event_bus, event_name, *args)
           klass = self
-          event_bus.subscribe(event_name) { |payload| klass.new.call(payload) }
+          event_bus.subscribe(event_name, *args) { |payload| klass.new.call(payload) }
         end
       end
     end

--- a/lib/hanami/events/mixin.rb
+++ b/lib/hanami/events/mixin.rb
@@ -25,9 +25,9 @@ module Hanami
 
       # Class interfaces
       module ClassMethods
-        def subscribe_to(event_bus, event_name, *args)
+        def subscribe_to(event_bus, event_name, kwargs = EMPTY_HASH)
           klass = self
-          event_bus.subscribe(event_name, *args) { |payload| klass.new.call(payload) }
+          event_bus.subscribe(event_name, kwargs) { |payload| klass.new.call(payload) }
         end
       end
     end

--- a/spec/unit/hanami/events/base_spec.rb
+++ b/spec/unit/hanami/events/base_spec.rb
@@ -16,9 +16,16 @@ RSpec.describe Hanami::Events::Base do
   describe 'subscribe' do
     it 'calls subscribe on adapter' do
       expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
-        receive(:subscribe).with('user.created', &handler)
+        receive(:subscribe).with('user.created', {}, &handler)
       )
       event_bus.subscribe('user.created', &handler)
+    end
+
+    it 'allows arbitrary args' do
+      expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
+        receive(:subscribe).with('user.created', id: 'test', &handler)
+      )
+      event_bus.subscribe('user.created', id: 'test', &handler)
     end
   end
 


### PR DESCRIPTION
For certain pub/sub systems, it's crucial to pass a `name` or `id` attribute to each subscriber so they can be individually identified. This ensures correct delivery of a message to a subscription. This PR makes it so the mixin will happily accept optional args and pass them to the adapter. Without this, it would not be possible to correctly implement an adapter for https://github.com/adHawk/hanami-events-cloud_pubsub