### PR TITLE
PoC: Create a map_to option for subscribe data object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Style/IndentHeredoc:
 Style/MixinGrouping:
   Exclude:
     - "spec/support/**/*"
+Style/GlobalVars:
+  Exclude:
+    - "spec/**/*"

--- a/README.md
+++ b/README.md
@@ -104,36 +104,6 @@ events.broadcast('user.created', user_id: 1)
 # => { user_id: 1 }
 ```
 
-### Runner
-For start hanami-events server you need to call `Hanami::Events::Runner` instance. It will create infinity loop for polling subscribers for your event object:
-
-```ruby
-redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: 'localhost', port: 6379) }
-events = Hanami::Events.initialize(:redis, redis: redis, logger: Logger.new(STDOUT))
-
-events.subscribe('user.created') { |payload| logger.info "Create user: #{payload}" }
-events.subscribe('user.created') { |payload| logger.info "Send notification to user: #{payload}" }
-
-events.subscribe('user.deleted') { |payload| logger.info "Delete user: #{payload}" }
-
-runner = Hanami::Events::Runner.new(events)
-runner.start # will start hanami event server
-```
-
-Now you can create events and send it to subscribers:
-```ruby
-redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: 'localhost', port: 6379) }
-events = Hanami::Events.initialize(:redis, redis: redis)
-
-events.broadcast('user.created', user_id: 1)
-# => I, [2018-09-27T02:17:40.186640 #12859]  INFO -- : Create user: {"user_id"=>1}
-# => I, [2018-09-27T02:17:40.186702 #12859]  INFO -- : Send notification to user: {"user_id"=>1}
-
-events.broadcast('user.deleted', user_id: 1)
-# => I, [2018-09-27T02:17:40.187096 #12859]  INFO -- : Delete user: {"user_id"=>1}
-```
-
-
 #### Mixin
 There is a mixin that allows to subscribe to events from class.
 
@@ -206,6 +176,47 @@ events.subscribe('*') { |payload| logger.info("Event: #{payload}" }
 events.broadcast('user.updated', user_id: 1)
 # => I, [2017-08-04T01:30:13.750700 #39778]  INFO -- : Event: { user_id: 1 }
 ```
+
+#### Event data objects
+You can use any typed data objects as a event data for you subscribers. For this just put `map_to` options to `subscribe` call:
+
+```ruby
+events = Hanami::Events.new(:memory_sync)
+events.subscribe('user.created', map_to: Events::UserCreated) { |payload| p payload }
+
+events.broadcast('user.created', user_id: 1)
+# => Events::UserCreated class
+```
+
+### Runner
+For start hanami-events server you need to call `Hanami::Events::Runner` instance. It will create infinity loop for polling subscribers for your event object:
+
+```ruby
+redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: 'localhost', port: 6379) }
+events = Hanami::Events.initialize(:redis, redis: redis, logger: Logger.new(STDOUT))
+
+events.subscribe('user.created') { |payload| logger.info "Create user: #{payload}" }
+events.subscribe('user.created') { |payload| logger.info "Send notification to user: #{payload}" }
+
+events.subscribe('user.deleted') { |payload| logger.info "Delete user: #{payload}" }
+
+runner = Hanami::Events::Runner.new(events)
+runner.start # will start hanami event server
+```
+
+Now you can create events and send it to subscribers:
+```ruby
+redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: 'localhost', port: 6379) }
+events = Hanami::Events.initialize(:redis, redis: redis)
+
+events.broadcast('user.created', user_id: 1)
+# => I, [2018-09-27T02:17:40.186640 #12859]  INFO -- : Create user: {"user_id"=>1}
+# => I, [2018-09-27T02:17:40.186702 #12859]  INFO -- : Send notification to user: {"user_id"=>1}
+
+events.broadcast('user.deleted', user_id: 1)
+# => I, [2018-09-27T02:17:40.187096 #12859]  INFO -- : Delete user: {"user_id"=>1}
+```
+
 
 ### Formatters
 You can use different formatters for displaying list of registered events for event instance. Now hanami-events support:

--- a/hanami-events.gemspec
+++ b/hanami-events.gemspec
@@ -26,9 +26,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-container", "~> 0.6"
 
   spec.add_development_dependency "xml-simple"
-  spec.add_development_dependency "redis"
-  spec.add_development_dependency "connection_pool"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
+
+  # testing
   spec.add_development_dependency "rspec", "~> 3.5"
+  spec.add_development_dependency "redis"
+  spec.add_development_dependency "connection_pool"
+
+  spec.add_development_dependency "dry-struct"
+  spec.add_development_dependency "shallow_attributes"
 end

--- a/lib/hanami/events/adapter/memory_async.rb
+++ b/lib/hanami/events/adapter/memory_async.rb
@@ -34,8 +34,8 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, _kwargs = EMPTY_HASH, &block)
-          @subscribers << Subscriber.new(event_name, block, @logger)
+        def subscribe(event_name, kwargs = EMPTY_HASH, &block)
+          @subscribers << Subscriber.new(event_name, block, @logger, kwargs[:map_to])
         end
 
         # Method for call all subscribers in one time

--- a/lib/hanami/events/adapter/memory_sync.rb
+++ b/lib/hanami/events/adapter/memory_sync.rb
@@ -32,8 +32,8 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, _kwargs = EMPTY_HASH, &block)
-          @subscribers << Subscriber.new(event_name, block, @logger)
+        def subscribe(event_name, kwargs = EMPTY_HASH, &block)
+          @subscribers << Subscriber.new(event_name, block, @logger, kwargs[:map_to])
         end
 
         # Method for call all subscribers in one time

--- a/lib/hanami/events/adapter/redis.rb
+++ b/lib/hanami/events/adapter/redis.rb
@@ -49,8 +49,8 @@ module Hanami
         # @param block [Block] to execute when event is broadcasted
         #
         # @since 0.1.0
-        def subscribe(event_name, _kwargs = EMPTY_HASH, &block)
-          @subscribers << Subscriber.new(event_name, block, @logger)
+        def subscribe(event_name, kwargs = EMPTY_HASH, &block)
+          @subscribers << Subscriber.new(event_name, block, @logger, kwargs[:map_to])
         end
 
         # Method for call all subscribers in one time

--- a/lib/hanami/events/subscriber.rb
+++ b/lib/hanami/events/subscriber.rb
@@ -10,7 +10,7 @@ module Hanami
       #
       # @api private
       class Runner
-        attr_reader :logger
+        attr_reader :logger, :map_to
 
         def initialize(handler, logger)
           @handler = handler
@@ -22,10 +22,11 @@ module Hanami
         end
       end
 
-      def initialize(event_name, event_handler, logger = nil)
+      def initialize(event_name, event_handler, logger = nil, data_struct_class = nil)
         @event_name = event_name
         @pattern_matcher = Matcher.new(event_name)
         @runner = Runner.new(event_handler, logger)
+        @data_struct_class = data_struct_class
       end
 
       # Call runner with payload if event match by subscribe pattern
@@ -37,7 +38,10 @@ module Hanami
       #
       # @api private
       def call(event_name, payload)
-        @runner.call(payload) if @pattern_matcher.match?(event_name)
+        return unless @pattern_matcher.match?(event_name)
+
+        data_object = @data_struct_class ? @data_struct_class.new(payload) : payload
+        @runner.call(data_object)
       end
 
       # Returns meta information for subscriber

--- a/spec/support/data_objects.rb
+++ b/spec/support/data_objects.rb
@@ -1,0 +1,31 @@
+require 'dry-struct'
+require 'shallow_attributes'
+
+
+class EventObjects
+  class Pure
+    attr_reader :user_id
+
+    def initialize(user_id:)
+      @user_id = user_id
+    end
+
+    def ==(other)
+      self.user_id == other.user_id
+    end
+  end
+
+  module Types
+    include Dry::Types.module
+  end
+
+  class Struct < Dry::Struct
+    attribute :user_id, Types::Coercible::Integer
+  end
+
+  class Shallow
+    include ShallowAttributes
+
+    attribute :user_id, Integer
+  end
+end

--- a/spec/unit/hanami/events/adapter/memory_sync_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_sync_spec.rb
@@ -24,5 +24,32 @@ RSpec.describe Hanami::Events::Adapter::MemorySync do
     end
 
     it { expect(subject).to eq [{ user_id: 1 }] }
+
+    context 'with mapping data object' do
+      before do
+        $pure_updated_user_array = []
+        adapter.subscribe('pure_user.updated', map_to: EventObjects::Pure) { |payload| $pure_updated_user_array << payload }
+
+        $struct_updated_user_array = []
+        adapter.subscribe('struct_user.updated', map_to: EventObjects::Struct) { |payload| $struct_updated_user_array << payload }
+
+        $shallow_updated_user_array = []
+        adapter.subscribe('shallow_user.updated', map_to: EventObjects::Shallow) { |payload| $shallow_updated_user_array << payload }
+      end
+
+      it 'calls #call method with payload on subscriber' do
+        adapter.broadcast('pure_user.updated', user_id: 1)
+        expect($pure_updated_user_array.count).to eq(1)
+        expect($pure_updated_user_array.first).to eq(EventObjects::Pure.new(user_id: 1))
+
+        adapter.broadcast('struct_user.updated', user_id: 1)
+        expect($struct_updated_user_array.count).to eq(1)
+        expect($struct_updated_user_array.first).to eq(EventObjects::Struct.new(user_id: 1))
+
+        adapter.broadcast('shallow_user.updated', user_id: 1)
+        expect($shallow_updated_user_array.count).to eq(1)
+        expect($shallow_updated_user_array.first).to eq(EventObjects::Shallow.new(user_id: 1))
+      end
+    end
   end
 end

--- a/spec/unit/hanami/events/runner_spec.rb
+++ b/spec/unit/hanami/events/runner_spec.rb
@@ -1,8 +1,6 @@
 require 'connection_pool'
 require 'redis'
 require 'hanami/events/runner'
-
-# rubocop:disable Style/GlobalVars
 RSpec.describe Hanami::Events::Runner do
   let(:event_runner) { described_class.new(event_instance) }
   let(:io) { StringIO.new }


### PR DESCRIPTION
Prof of concept for https://github.com/hanami/events/issues/64

Instead of creating event data object - just allow to use any PORO object for mapping to subscriber data