### PR TITLE
Allow to use async memory adapter without runner

### DIFF
--- a/lib/hanami/events/adapter/memory_async.rb
+++ b/lib/hanami/events/adapter/memory_async.rb
@@ -38,13 +38,20 @@ module Hanami
         # @since 0.1.0
         def subscribe(event_name, kwargs = EMPTY_HASH, &block)
           @subscribers << Subscriber.new(event_name, block, @logger, kwargs[:map_to])
+
+          return if thread_spawned?
+          thread_spawned!
+
+          Thread.new do
+            loop { call_subscribers }
+          end
         end
 
         # Method for call all subscribers in one time
         #
         # @since 0.2.0
         def pull_subscribers
-          call_subscribers
+          true
         end
 
         private

--- a/lib/hanami/events/runner.rb
+++ b/lib/hanami/events/runner.rb
@@ -11,7 +11,7 @@ module Hanami
         @options = options
       end
 
-      def start(threads: 5) # rubocop:disable Metrics/AbcSize
+      def start(threads: 5) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         logger.info "Running in #{RUBY_DESCRIPTION}"
         logger.info "Started server with #{event_instance.adapter.class} adapter"
 

--- a/spec/unit/hanami/events/adapter/memory_async_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_async_spec.rb
@@ -13,17 +13,7 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
   end
 
   describe '#pull_subscribers' do
-    before do
-      $user_array = []
-      adapter.subscribe('user.created') { |payload| $user_array << payload }
-    end
-
-    it 'pull all adapter subscribers one time' do
-      adapter.broadcast('user.created', user_id: 1)
-      expect($user_array).to eq []
-      adapter.pull_subscribers
-      expect($user_array).to eq [{ user_id: 1 }]
-    end
+    it { expect(adapter.pull_subscribers).to eq true }
   end
 
   describe '#broadcast' do
@@ -33,8 +23,8 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
     end
 
     it 'returns uuid for each broadcast' do
-      eid1 = adapter.broadcast('user.created', user_id: 1)
-      eid2 = adapter.broadcast('user.created', user_id: 2)
+      eid1 = adapter.broadcast('olduser.created', user_id: 1)
+      eid2 = adapter.broadcast('olduser.created', user_id: 2)
 
       expect(eid1).to be_a(String)
       expect(eid1).to be_a(String)
@@ -44,7 +34,7 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
 
     it 'calls #call method with payload on subscriber' do
       adapter.broadcast('user.created', user_id: 1)
-      adapter.pull_subscribers
+      sleep 0.2
       expect($user_array).to eq [{ user_id: 1 }]
     end
 
@@ -63,7 +53,7 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
 
       it 'calls #call method with payload on subscriber' do
         adapter.broadcast('comment.created', user_id: 1)
-        adapter.pull_subscribers
+        sleep 0.2
         expect($comment_array).to eq [{ user_id: 1 }, { user_id: 1 }]
       end
     end
@@ -81,17 +71,17 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
 
       it 'calls #call method with payload on subscriber' do
         adapter.broadcast('pure_user.updated', user_id: 1)
-        adapter.pull_subscribers
+        sleep 0.2
         expect($pure_updated_user_array.count).to eq(1)
         expect($pure_updated_user_array.first).to eq(EventObjects::Pure.new(user_id: 1))
 
         adapter.broadcast('struct_user.updated', user_id: 1)
-        adapter.pull_subscribers
+        sleep 0.2
         expect($struct_updated_user_array.count).to eq(1)
         expect($struct_updated_user_array.first).to eq(EventObjects::Struct.new(user_id: 1))
 
         adapter.broadcast('shallow_user.updated', user_id: 1)
-        adapter.pull_subscribers
+        sleep 0.2
         expect($shallow_updated_user_array.count).to eq(1)
         expect($shallow_updated_user_array.first).to eq(EventObjects::Shallow.new(user_id: 1))
       end

--- a/spec/unit/hanami/events/version_spec.rb
+++ b/spec/unit/hanami/events/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Events::VERSION" do
   it 'exposes version' do
-    expect(Hanami::Events::VERSION).to eq('0.1.0')
+    expect(Hanami::Events::VERSION).to eq('0.2.0')
   end
 end


### PR DESCRIPTION
We have some thread specific issues now with runner and async memory adapter. For fixing it we say that runner is only for standalone event server for redis or other pubsub systems