### PR TITLE
Fix NameError: uninitialized constant Concurrent::Async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
@@ -5,8 +7,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in hanami-events.gemspec
 gemspec
 
-gem 'yard', require: false unless ENV['TRAVIS']
+gem "yard", require: false unless ENV["TRAVIS"]
 
-gem 'simplecov', require: false, group: :test
-gem 'mutant-rspec'
-gem 'rubocop',   '0.50.0', require: false
+gem "simplecov", require: false, group: :test
+gem "mutant-rspec"
+gem "rubocop",   "0.50.0", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 require "rake/testtask"
 require "bundler/gem_tasks"

--- a/hanami-events.gemspec
+++ b/hanami-events.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-container", "~> 0.6"
 
   spec.add_development_dependency "xml-simple"
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 
   # testing
   spec.add_development_dependency "rspec", "~> 3.5"

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "hanami/events/adapter"
 require "hanami/events/serializer"
 require "hanami/events/formatter"
@@ -40,7 +42,7 @@ module Hanami
       def new(adapter_name, **options)
         Base.new(adapter_name, options)
       end
-      alias initialize new
+      alias_method :initialize, :new
     end
   end
 end

--- a/lib/hanami/events/adapter.rb
+++ b/lib/hanami/events/adapter.rb
@@ -1,4 +1,6 @@
-require 'dry/container'
+# frozen_string_literal: true
+
+require "dry/container"
 
 module Hanami
   module Events
@@ -13,17 +15,17 @@ module Hanami
       extend Dry::Container::Mixin
 
       register(:memory_sync) do
-        require_relative 'adapter/memory_sync'
+        require_relative "adapter/memory_sync"
         MemorySync
       end
 
       register(:memory_async) do
-        require_relative 'adapter/memory_async'
+        require_relative "adapter/memory_async"
         MemoryAsync
       end
 
       register(:redis) do
-        require_relative 'adapter/redis'
+        require_relative "adapter/redis"
         Redis
       end
     end

--- a/lib/hanami/events/adapter/memory_async.rb
+++ b/lib/hanami/events/adapter/memory_async.rb
@@ -1,4 +1,6 @@
-require 'securerandom'
+# frozen_string_literal: true
+
+require "securerandom"
 
 module Hanami
   module Events
@@ -26,7 +28,7 @@ module Hanami
         # @since 0.1.0
         def broadcast(event_name, payload)
           event_id = SecureRandom.uuid
-          @event_queue << { id: event_id, name: event_name, payload: payload }
+          @event_queue << {id: event_id, name: event_name, payload: payload}
           event_id
         end
 

--- a/lib/hanami/events/adapter/memory_sync.rb
+++ b/lib/hanami/events/adapter/memory_sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     class Adapter

--- a/lib/hanami/events/adapter/redis.rb
+++ b/lib/hanami/events/adapter/redis.rb
@@ -1,5 +1,7 @@
-require 'json'
-require 'securerandom'
+# frozen_string_literal: true
+
+require "json"
+require "securerandom"
 
 module Hanami
   module Events
@@ -10,8 +12,8 @@ module Hanami
       #
       # @api private
       class Redis
-        DEFAULT_STREAM = 'hanami.events'.freeze
-        EVENT_STORE = 'hanami.event_store'.freeze
+        DEFAULT_STREAM = "hanami.events"
+        EVENT_STORE = "hanami.event_store"
 
         attr_reader :subscribers, :logger
 
@@ -75,12 +77,12 @@ module Hanami
         end
 
         def call_subscribers(message)
-          @subscribers.each { |subscriber| subscriber.call(message['event_name'], message['payload']) }
+          @subscribers.each { |subscriber| subscriber.call(message["event_name"], message["payload"]) }
         end
 
         def with_connection_pool(redis)
           return redis if redis.is_a?(ConnectionPool)
-          raise ArgumentError, 'Please, provide an instance of Redis' unless redis.is_a?(::Redis)
+          raise ArgumentError, "Please, provide an instance of Redis" unless redis.is_a?(::Redis)
 
           ConnectionPool.new(size: 5, timeout: 5) { redis }
         end

--- a/lib/hanami/events/base.rb
+++ b/lib/hanami/events/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     # Base event class with public methods

--- a/lib/hanami/events/formatter.rb
+++ b/lib/hanami/events/formatter.rb
@@ -1,4 +1,6 @@
-require 'dry/container'
+# frozen_string_literal: true
+
+require "dry/container"
 
 module Hanami
   module Events
@@ -11,17 +13,17 @@ module Hanami
       extend Dry::Container::Mixin
 
       register(:plain_text) do
-        require_relative 'formatter/plain_text'
+        require_relative "formatter/plain_text"
         PlainText
       end
 
       register(:json) do
-        require_relative 'formatter/json'
+        require_relative "formatter/json"
         Json
       end
 
       register(:xml) do
-        require_relative 'formatter/xml'
+        require_relative "formatter/xml"
         Xml
       end
     end

--- a/lib/hanami/events/formatter/json.rb
+++ b/lib/hanami/events/formatter/json.rb
@@ -1,4 +1,6 @@
-require 'json'
+# frozen_string_literal: true
+
+require "json"
 
 module Hanami
   module Events
@@ -22,7 +24,7 @@ module Hanami
         #
         # @since 0.1.0
         def format
-          { events: @events_meta }.to_json
+          {events: @events_meta}.to_json
         end
       end
     end

--- a/lib/hanami/events/formatter/plain_text.rb
+++ b/lib/hanami/events/formatter/plain_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     class Formatter

--- a/lib/hanami/events/formatter/xml.rb
+++ b/lib/hanami/events/formatter/xml.rb
@@ -1,4 +1,6 @@
-require 'xmlsimple'
+# frozen_string_literal: true
+
+require "xmlsimple"
 
 module Hanami
   module Events

--- a/lib/hanami/events/matcher.rb
+++ b/lib/hanami/events/matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     # Matcher for event names.
@@ -11,23 +13,23 @@ module Hanami
     #
     # @api private
     class Matcher
-      MATCH_ALL_CHARS = '.*'.freeze
-      RANGE_PATTERN = '*'.freeze
+      MATCH_ALL_CHARS = ".*"
+      RANGE_PATTERN = "*"
 
       def initialize(pattern)
         @pattern = pattern.is_a?(Regexp) ? pattern : Regexp.new(to_regexp_string(pattern))
       end
 
       def match?(event_name)
-        !!@pattern.match(event_name) # rubocop:disable Style/DoubleNegation
+        !!@pattern.match(event_name)
       end
 
       private
 
       def to_regexp_string(pattern)
-        pattern.split('.')
-               .map { |p| p == RANGE_PATTERN ? MATCH_ALL_CHARS : Regexp.escape(p) }
-               .join('\.')
+        pattern.split(".")
+          .map { |p| p == RANGE_PATTERN ? MATCH_ALL_CHARS : Regexp.escape(p) }
+          .join('\.')
       end
     end
   end

--- a/lib/hanami/events/mixin.rb
+++ b/lib/hanami/events/mixin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     # Mixin that extends class by `subscribe_to` method.

--- a/lib/hanami/events/runner.rb
+++ b/lib/hanami/events/runner.rb
@@ -1,4 +1,6 @@
-require 'concurrent'
+# frozen_string_literal: true
+
+require "concurrent"
 
 module Hanami
   module Events
@@ -13,7 +15,7 @@ module Hanami
         @options = options
       end
 
-      def start(threads: 5) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def start(threads: 5)
         logger.info "Running in #{RUBY_DESCRIPTION}"
         logger.info "Started server with #{event_instance.adapter.class} adapter"
 

--- a/lib/hanami/events/runner.rb
+++ b/lib/hanami/events/runner.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 module Hanami
   module Events
     # Class for start subscribe loop runner

--- a/lib/hanami/events/serializer.rb
+++ b/lib/hanami/events/serializer.rb
@@ -1,4 +1,6 @@
-require 'dry/container'
+# frozen_string_literal: true
+
+require "dry/container"
 
 module Hanami
   module Events
@@ -7,7 +9,7 @@ module Hanami
       extend Dry::Container::Mixin
 
       register(:json) do
-        require_relative 'serializer/json'
+        require_relative "serializer/json"
         Json
       end
     end

--- a/lib/hanami/events/serializer/json.rb
+++ b/lib/hanami/events/serializer/json.rb
@@ -1,4 +1,6 @@
-require 'json'
+# frozen_string_literal: true
+
+require "json"
 
 module Hanami
   module Events

--- a/lib/hanami/events/subscriber.rb
+++ b/lib/hanami/events/subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     # Subscriber class for calling subscriber blocks
@@ -50,7 +52,7 @@ module Hanami
       #
       # @api private
       def meta
-        { name: @event_name }
+        {name: @event_name}
       end
     end
   end

--- a/lib/hanami/events/version.rb
+++ b/lib/hanami/events/version.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Hanami
   module Events
     # @since 0.1.0
     # @api private
-    VERSION = "0.2.1".freeze
+    VERSION = "0.2.1"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
-require 'simplecov'
-SimpleCov.start { add_filter '/spec' }
+# frozen_string_literal: true
 
-require 'hanami/events'
+require "simplecov"
+SimpleCov.start { add_filter "/spec" }
+
+require "hanami/events"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -20,7 +22,7 @@ RSpec.configure do |config|
 
   config.warnings = true
 
-  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.default_formatter = "doc" if config.files_to_run.one?
   config.profile_examples = 10
 
   config.order = :random

--- a/spec/unit/hanami/events/adapter/memory_async_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_async_spec.rb
@@ -1,30 +1,32 @@
-require 'hanami/events/adapter/memory_async'
-require_relative '../../../../support/data_objects'
+# frozen_string_literal: true
+
+require "hanami/events/adapter/memory_async"
+require_relative "../../../../support/data_objects"
 
 RSpec.describe Hanami::Events::Adapter::MemoryAsync do
   let(:adapter) { described_class.new }
 
-  describe '#subscribe' do
-    it 'pushes subscriber to the list of subscribers' do
+  describe "#subscribe" do
+    it "pushes subscriber to the list of subscribers" do
       expect do
-        adapter.subscribe('event.name') { |payload| payload }
+        adapter.subscribe("event.name") { |payload| payload }
       end.to change { adapter.subscribers.count }.by(1)
     end
   end
 
-  describe '#pull_subscribers' do
+  describe "#pull_subscribers" do
     it { expect(adapter.pull_subscribers).to eq true }
   end
 
-  describe '#broadcast' do
+  describe "#broadcast" do
     before do
       $user_array = []
-      adapter.subscribe('user.created') { |payload| $user_array << payload }
+      adapter.subscribe("user.created") { |payload| $user_array << payload }
     end
 
-    it 'returns uuid for each broadcast' do
-      eid1 = adapter.broadcast('olduser.created', user_id: 1)
-      eid2 = adapter.broadcast('olduser.created', user_id: 2)
+    it "returns uuid for each broadcast" do
+      eid1 = adapter.broadcast("olduser.created", user_id: 1)
+      eid2 = adapter.broadcast("olduser.created", user_id: 2)
 
       expect(eid1).to be_a(String)
       expect(eid1).to be_a(String)
@@ -32,55 +34,55 @@ RSpec.describe Hanami::Events::Adapter::MemoryAsync do
       expect(eid1).to_not eq(eid2)
     end
 
-    it 'calls #call method with payload on subscriber' do
-      adapter.broadcast('user.created', user_id: 1)
+    it "calls #call method with payload on subscriber" do
+      adapter.broadcast("user.created", user_id: 1)
       sleep 0.2
-      expect($user_array).to eq [{ user_id: 1 }]
+      expect($user_array).to eq [{user_id: 1}]
     end
 
-    context 'when system have 2 subscribes ' do
+    context "when system have 2 subscribes " do
       before do
         $comment_array = []
 
-        adapter.subscribe('comment.created') do |payload|
+        adapter.subscribe("comment.created") do |payload|
           $comment_array << payload
         end
 
-        adapter.subscribe('comment.created') do |payload|
+        adapter.subscribe("comment.created") do |payload|
           $comment_array << payload
         end
       end
 
-      it 'calls #call method with payload on subscriber' do
-        adapter.broadcast('comment.created', user_id: 1)
+      it "calls #call method with payload on subscriber" do
+        adapter.broadcast("comment.created", user_id: 1)
         sleep 0.2
-        expect($comment_array).to eq [{ user_id: 1 }, { user_id: 1 }]
+        expect($comment_array).to eq [{user_id: 1}, {user_id: 1}]
       end
     end
 
-    context 'with mapping data object' do
+    context "with mapping data object" do
       before do
         $pure_updated_user_array = []
-        adapter.subscribe('pure_user.updated', map_to: EventObjects::Pure) { |payload| $pure_updated_user_array << payload }
+        adapter.subscribe("pure_user.updated", map_to: EventObjects::Pure) { |payload| $pure_updated_user_array << payload }
 
         $struct_updated_user_array = []
-        adapter.subscribe('struct_user.updated', map_to: EventObjects::Struct) { |payload| $struct_updated_user_array << payload }
+        adapter.subscribe("struct_user.updated", map_to: EventObjects::Struct) { |payload| $struct_updated_user_array << payload }
         $shallow_updated_user_array = []
-        adapter.subscribe('shallow_user.updated', map_to: EventObjects::Shallow) { |payload| $shallow_updated_user_array << payload }
+        adapter.subscribe("shallow_user.updated", map_to: EventObjects::Shallow) { |payload| $shallow_updated_user_array << payload }
       end
 
-      it 'calls #call method with payload on subscriber' do
-        adapter.broadcast('pure_user.updated', user_id: 1)
+      it "calls #call method with payload on subscriber" do
+        adapter.broadcast("pure_user.updated", user_id: 1)
         sleep 0.2
         expect($pure_updated_user_array.count).to eq(1)
         expect($pure_updated_user_array.first).to eq(EventObjects::Pure.new(user_id: 1))
 
-        adapter.broadcast('struct_user.updated', user_id: 1)
+        adapter.broadcast("struct_user.updated", user_id: 1)
         sleep 0.2
         expect($struct_updated_user_array.count).to eq(1)
         expect($struct_updated_user_array.first).to eq(EventObjects::Struct.new(user_id: 1))
 
-        adapter.broadcast('shallow_user.updated', user_id: 1)
+        adapter.broadcast("shallow_user.updated", user_id: 1)
         sleep 0.2
         expect($shallow_updated_user_array.count).to eq(1)
         expect($shallow_updated_user_array.first).to eq(EventObjects::Shallow.new(user_id: 1))

--- a/spec/unit/hanami/events/adapter/memory_sync_spec.rb
+++ b/spec/unit/hanami/events/adapter/memory_sync_spec.rb
@@ -1,52 +1,54 @@
-require 'hanami/events/adapter/memory_sync'
+# frozen_string_literal: true
+
+require "hanami/events/adapter/memory_sync"
 
 RSpec.describe Hanami::Events::Adapter::MemorySync do
   let(:adapter) { described_class.new }
 
-  describe '#subscribe' do
-    it 'pushes subscriber to the list of subscribers' do
+  describe "#subscribe" do
+    it "pushes subscriber to the list of subscribers" do
       expect do
-        adapter.subscribe('event.name') { |payload| payload }
+        adapter.subscribe("event.name") { |payload| payload }
       end.to change { adapter.subscribers.count }.by(1)
     end
   end
 
-  describe '#broadcast' do
+  describe "#broadcast" do
     before do
-      adapter.subscribe('user.created') { |payload| payload }
+      adapter.subscribe("user.created") { |payload| payload }
     end
 
-    subject { adapter.broadcast('user.created', user_id: 1) }
+    subject { adapter.broadcast("user.created", user_id: 1) }
 
-    it 'calls #call method with payload on subscriber' do
-      expect(adapter.subscribers.first).to receive(:call).with('user.created', user_id: 1)
+    it "calls #call method with payload on subscriber" do
+      expect(adapter.subscribers.first).to receive(:call).with("user.created", user_id: 1)
       subject
     end
 
-    it { expect(subject).to eq [{ user_id: 1 }] }
+    it { expect(subject).to eq [{user_id: 1}] }
 
-    context 'with mapping data object' do
+    context "with mapping data object" do
       before do
         $pure_updated_user_array = []
-        adapter.subscribe('pure_user.updated', map_to: EventObjects::Pure) { |payload| $pure_updated_user_array << payload }
+        adapter.subscribe("pure_user.updated", map_to: EventObjects::Pure) { |payload| $pure_updated_user_array << payload }
 
         $struct_updated_user_array = []
-        adapter.subscribe('struct_user.updated', map_to: EventObjects::Struct) { |payload| $struct_updated_user_array << payload }
+        adapter.subscribe("struct_user.updated", map_to: EventObjects::Struct) { |payload| $struct_updated_user_array << payload }
 
         $shallow_updated_user_array = []
-        adapter.subscribe('shallow_user.updated', map_to: EventObjects::Shallow) { |payload| $shallow_updated_user_array << payload }
+        adapter.subscribe("shallow_user.updated", map_to: EventObjects::Shallow) { |payload| $shallow_updated_user_array << payload }
       end
 
-      it 'calls #call method with payload on subscriber' do
-        adapter.broadcast('pure_user.updated', user_id: 1)
+      it "calls #call method with payload on subscriber" do
+        adapter.broadcast("pure_user.updated", user_id: 1)
         expect($pure_updated_user_array.count).to eq(1)
         expect($pure_updated_user_array.first).to eq(EventObjects::Pure.new(user_id: 1))
 
-        adapter.broadcast('struct_user.updated', user_id: 1)
+        adapter.broadcast("struct_user.updated", user_id: 1)
         expect($struct_updated_user_array.count).to eq(1)
         expect($struct_updated_user_array.first).to eq(EventObjects::Struct.new(user_id: 1))
 
-        adapter.broadcast('shallow_user.updated', user_id: 1)
+        adapter.broadcast("shallow_user.updated", user_id: 1)
         expect($shallow_updated_user_array.count).to eq(1)
         expect($shallow_updated_user_array.first).to eq(EventObjects::Shallow.new(user_id: 1))
       end

--- a/spec/unit/hanami/events/adapter/redis_spec.rb
+++ b/spec/unit/hanami/events/adapter/redis_spec.rb
@@ -1,85 +1,87 @@
-require 'hanami/events/adapter/redis'
-require 'connection_pool'
-require 'redis'
+# frozen_string_literal: true
+
+require "hanami/events/adapter/redis"
+require "connection_pool"
+require "redis"
 
 RSpec.describe Hanami::Events::Adapter::Redis do
   let(:handler) { proc { |payload| payload } }
   let(:adapter) { described_class.new(redis: redis) }
 
   before do
-    allow(SecureRandom).to receive(:uuid).and_return('abcd1234')
+    allow(SecureRandom).to receive(:uuid).and_return("abcd1234")
   end
 
-  describe '#initialize' do
+  describe "#initialize" do
     let(:redis) { Redis.new }
 
-    it 'wraps redis instance into connection pool' do
+    it "wraps redis instance into connection pool" do
       expect_any_instance_of(ConnectionPool).to receive(:with)
-      adapter.broadcast('user.created', user_id: 1)
+      adapter.broadcast("user.created", user_id: 1)
     end
 
-    context 'without redis in params' do
-      it 'raises ArgumentError' do
+    context "without redis in params" do
+      it "raises ArgumentError" do
         expect { described_class.new(redis: nil) }.to raise_error(ArgumentError)
       end
     end
 
-    context 'accepts stream param' do
+    context "accepts stream param" do
       let(:event) do
         {
-          id: 'abcd1234', event_name: 'user.created', payload: { user_id: 1 }
+          id: "abcd1234", event_name: "user.created", payload: {user_id: 1}
         }.to_json
       end
 
-      it 'uses hanami.events as default stream' do
+      it "uses hanami.events as default stream" do
         expect_any_instance_of(Redis).to(
-          receive(:lpush).with('hanami.events', event)
+          receive(:lpush).with("hanami.events", event)
         )
-        adapter.broadcast('user.created', user_id: 1)
+        adapter.broadcast("user.created", user_id: 1)
       end
 
-      it 'uses stream param when passed' do
-        adapter = described_class.new(redis: redis, stream: 'custom.stream')
+      it "uses stream param when passed" do
+        adapter = described_class.new(redis: redis, stream: "custom.stream")
 
         expect_any_instance_of(Redis).to(
-          receive(:lpush).with('custom.stream', event)
+          receive(:lpush).with("custom.stream", event)
         )
-        adapter.broadcast('user.created', user_id: 1)
+        adapter.broadcast("user.created", user_id: 1)
       end
     end
   end
 
-  describe '#subscribe' do
+  describe "#subscribe" do
     let(:redis) { ConnectionPool.new(size: 5, timeout: 5) { Redis.new } }
     before { redis.with(&:flushall) }
     after { redis.with(&:flushall) }
 
-    it 'pushes subscriber to the list of subscribers' do
+    it "pushes subscriber to the list of subscribers" do
       expect do
-        adapter.subscribe('event.name', &handler)
+        adapter.subscribe("event.name", &handler)
       end.to change { adapter.subscribers.count }.by(1)
     end
 
     context do
       let(:events) { redis.with { |conn| conn.lrange(described_class::EVENT_STORE, 0, -1) } }
 
-      it 'saves event to event store' do
-        adapter.subscribe('user.created', &handler)
-        adapter.broadcast('user.created', user_id: 1)
+      it "saves event to event store" do
+        adapter.subscribe("user.created", &handler)
+        adapter.broadcast("user.created", user_id: 1)
         adapter.pull_subscribers
         expect(events).to eq ['{"id":"abcd1234","event_name":"user.created","payload":{"user_id":1}}']
       end
     end
 
-    xcontext 'with mapping data object' do
+    xcontext "with mapping data object" do
       [EventObjects::Pure, EventObjects::Struct, EventObjects::Shallow].each do |event_class|
         before do
           $updated_user_array = []
-          adapter.subscribe('user.updated', map_to: event_class) { |payload| $updated_user_array << payload }
+          adapter.subscribe("user.updated", map_to: event_class) { |payload| $updated_user_array << payload }
         end
 
-        it 'calls #call method with payload on subscriber' do
-          adapter.broadcast('user.updated', user_id: 1)
+        it "calls #call method with payload on subscriber" do
+          adapter.broadcast("user.updated", user_id: 1)
           adapter.pull_subscribers
           expect($updated_user_array.count).to eq(1)
           expect($updated_user_array.first).to eq(event_class.new(user_id: 1))
@@ -88,16 +90,16 @@ RSpec.describe Hanami::Events::Adapter::Redis do
     end
   end
 
-  describe '#broadcast' do
+  describe "#broadcast" do
     let(:redis) { ConnectionPool.new(size: 5, timeout: 5) { Redis.new } }
     before { redis.with(&:flushall) }
     after { redis.with(&:flushall) }
 
-    it 'calls redis with proper params' do
+    it "calls redis with proper params" do
       expect_any_instance_of(Redis).to receive(:lpush).with(
-        'hanami.events', { id: 'abcd1234', event_name: 'user.created', payload: { user_id: 1 } }.to_json
+        "hanami.events", {id: "abcd1234", event_name: "user.created", payload: {user_id: 1}}.to_json
       )
-      adapter.broadcast('user.created', user_id: 1)
+      adapter.broadcast("user.created", user_id: 1)
     end
   end
 end

--- a/spec/unit/hanami/events/adapter_spec.rb
+++ b/spec/unit/hanami/events/adapter_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Events::Adapter do
-  describe '.keys' do
-    it { expect(described_class.keys).to include('memory_sync', 'memory_async', 'redis') }
+  describe ".keys" do
+    it { expect(described_class.keys).to include("memory_sync", "memory_async", "redis") }
   end
 
-  describe '.[]' do
+  describe ".[]" do
     it { expect(described_class[:memory_sync]).to eq(Hanami::Events::Adapter::MemorySync) }
     it { expect(described_class[:memory_async]).to eq(Hanami::Events::Adapter::MemoryAsync) }
     it { expect(described_class[:redis]).to eq(Hanami::Events::Adapter::Redis) }

--- a/spec/unit/hanami/events/base_spec.rb
+++ b/spec/unit/hanami/events/base_spec.rb
@@ -1,46 +1,48 @@
-require 'hanami/events/adapter/memory_sync'
+# frozen_string_literal: true
+
+require "hanami/events/adapter/memory_sync"
 
 RSpec.describe Hanami::Events::Base do
   let(:event_bus) { described_class.new(:memory_sync, {}) }
   let(:handler) { proc { |payload| payload } }
 
-  describe 'broadcast' do
-    it 'calls broadcast on adapter' do
+  describe "broadcast" do
+    it "calls broadcast on adapter" do
       expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
-        receive(:broadcast).with('user.created', user_id: 1)
+        receive(:broadcast).with("user.created", user_id: 1)
       )
-      event_bus.broadcast('user.created', user_id: 1)
+      event_bus.broadcast("user.created", user_id: 1)
     end
   end
 
-  describe 'subscribe' do
-    it 'calls subscribe on adapter' do
+  describe "subscribe" do
+    it "calls subscribe on adapter" do
       expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
-        receive(:subscribe).with('user.created', {}, &handler)
+        receive(:subscribe).with("user.created", {}, &handler)
       )
-      event_bus.subscribe('user.created', &handler)
+      event_bus.subscribe("user.created", &handler)
     end
 
-    it 'allows arbitrary args' do
+    it "allows arbitrary args" do
       expect_any_instance_of(Hanami::Events::Adapter::MemorySync).to(
-        receive(:subscribe).with('user.created', id: 'test', &handler)
+        receive(:subscribe).with("user.created", id: "test", &handler)
       )
-      event_bus.subscribe('user.created', id: 'test', &handler)
+      event_bus.subscribe("user.created", id: "test", &handler)
     end
   end
 
-  describe 'subscribed_events' do
+  describe "subscribed_events" do
     before do
-      event_bus.subscribe('user.created', &handler)
-      event_bus.subscribe('user.updated', &handler)
-      event_bus.subscribe('user.deleted', handler)
+      event_bus.subscribe("user.created", &handler)
+      event_bus.subscribe("user.updated", &handler)
+      event_bus.subscribe("user.deleted", handler)
     end
 
-    it 'shows meta information for subscribed events' do
+    it "shows meta information for subscribed events" do
       expect(event_bus.subscribed_events).to eq [
-        { name: 'user.created' },
-        { name: 'user.updated' },
-        { name: 'user.deleted' }
+        {name: "user.created"},
+        {name: "user.updated"},
+        {name: "user.deleted"}
       ]
     end
   end

--- a/spec/unit/hanami/events/formatter/json_spec.rb
+++ b/spec/unit/hanami/events/formatter/json_spec.rb
@@ -1,20 +1,22 @@
-require 'hanami/events/formatter/json'
+# frozen_string_literal: true
+
+require "hanami/events/formatter/json"
 
 RSpec.describe Hanami::Events::Formatter::Json do
   let(:formatter) { described_class.new(data) }
   let(:data) do
     [
-      { title: '*' },
-      { title: 'user.*' },
-      { title: 'user.created' },
-      { title: 'post.*' },
-      { title: 'post.created' }
+      {title: "*"},
+      {title: "user.*"},
+      {title: "user.created"},
+      {title: "post.*"},
+      {title: "post.created"}
     ]
   end
 
-  describe '#format' do
-    it 'formats events data' do
-      expect(formatter.format).to eq({ events: data }.to_json)
+  describe "#format" do
+    it "formats events data" do
+      expect(formatter.format).to eq({events: data}.to_json)
     end
   end
 end

--- a/spec/unit/hanami/events/formatter/plain_text_spec.rb
+++ b/spec/unit/hanami/events/formatter/plain_text_spec.rb
@@ -1,19 +1,21 @@
-require 'hanami/events/formatter/plain_text'
+# frozen_string_literal: true
+
+require "hanami/events/formatter/plain_text"
 
 RSpec.describe Hanami::Events::Formatter::PlainText do
   let(:formatter) { described_class.new(data) }
   let(:data) do
     [
-      { name: '*' },
-      { name: 'user.*' },
-      { name: 'user.created' },
-      { name: 'post.*' },
-      { name: 'post.created' }
+      {name: "*"},
+      {name: "user.*"},
+      {name: "user.created"},
+      {name: "post.*"},
+      {name: "post.created"}
     ]
   end
 
-  describe '#format' do
-    it 'formats events data' do
+  describe "#format" do
+    it "formats events data" do
       expect(formatter.format).to eq "Events:\n\t\"*\"\n\t\"user.*\"\n\t\"user.created\"\n\t\"post.*\"\n\t\"post.created\""
     end
   end

--- a/spec/unit/hanami/events/formatter/xml_spec.rb
+++ b/spec/unit/hanami/events/formatter/xml_spec.rb
@@ -1,18 +1,20 @@
-require 'hanami/events/formatter/xml'
+# frozen_string_literal: true
+
+require "hanami/events/formatter/xml"
 
 RSpec.describe Hanami::Events::Formatter::Xml do
   let(:formatter) { described_class.new(data) }
 
-  describe '#format' do
+  describe "#format" do
     let(:data) do
       [
-        { title: '*' },
-        { title: 'user.*' }
+        {title: "*"},
+        {title: "user.*"}
       ]
     end
 
     it { expect(formatter.format).to eq(XmlSimple.xml_out(events: data)) }
-    it 'returns valid xml string' do
+    it "returns valid xml string" do
       expect(formatter.format).to eq "<opt>\n  <events title=\"*\" />\n  <events title=\"user.*\" />\n</opt>\n"
     end
   end

--- a/spec/unit/hanami/events/formatter_spec.rb
+++ b/spec/unit/hanami/events/formatter_spec.rb
@@ -1,11 +1,13 @@
-require 'hanami/events/formatter'
+# frozen_string_literal: true
+
+require "hanami/events/formatter"
 
 RSpec.describe Hanami::Events::Formatter do
-  describe '.keys' do
+  describe ".keys" do
     it { expect(described_class.keys).to eq %w[plain_text json xml] }
   end
 
-  describe '.[]' do
+  describe ".[]" do
     it { expect(described_class[:plain_text]).to eq(Hanami::Events::Formatter::PlainText) }
     it { expect(described_class[:json]).to eq(Hanami::Events::Formatter::Json) }
     it { expect(described_class[:xml]).to eq(Hanami::Events::Formatter::Xml) }

--- a/spec/unit/hanami/events/matcher_spec.rb
+++ b/spec/unit/hanami/events/matcher_spec.rb
@@ -1,76 +1,78 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Events::Matcher do
   let(:matcher) { described_class.new(pattern) }
 
-  context 'when pattern is regular exeption' do
+  context "when pattern is regular exeption" do
     let(:pattern) { /\Auser/ }
 
-    it { expect(matcher.match?('user.created')).to be true }
-    it { expect(matcher.match?('user.updated')).to be true }
-    it { expect(matcher.match?('post.created')).to be false }
+    it { expect(matcher.match?("user.created")).to be true }
+    it { expect(matcher.match?("user.updated")).to be true }
+    it { expect(matcher.match?("post.created")).to be false }
   end
 
-  context 'when pattern match only one event' do
-    let(:pattern) { 'user.created' }
+  context "when pattern match only one event" do
+    let(:pattern) { "user.created" }
 
-    it { expect(matcher.match?('user.created')).to be true }
-    it { expect(matcher.match?('user.updated')).to be false }
-    it { expect(matcher.match?('post.created')).to be false }
+    it { expect(matcher.match?("user.created")).to be true }
+    it { expect(matcher.match?("user.updated")).to be false }
+    it { expect(matcher.match?("post.created")).to be false }
   end
 
-  context 'when pattern match range of events' do
-    let(:pattern) { 'user.*' }
+  context "when pattern match range of events" do
+    let(:pattern) { "user.*" }
 
-    it { expect(matcher.match?('user.created')).to be true }
-    it { expect(matcher.match?('user.updated')).to be true }
-    it { expect(matcher.match?('post.created')).to be false }
+    it { expect(matcher.match?("user.created")).to be true }
+    it { expect(matcher.match?("user.updated")).to be true }
+    it { expect(matcher.match?("post.created")).to be false }
 
-    context 'and range on beginig' do
-      let(:pattern) { '*.created' }
+    context "and range on beginig" do
+      let(:pattern) { "*.created" }
 
-      it { expect(matcher.match?('user.created')).to be true }
-      it { expect(matcher.match?('user.updated')).to be false }
-      it { expect(matcher.match?('post.created')).to be true }
+      it { expect(matcher.match?("user.created")).to be true }
+      it { expect(matcher.match?("user.updated")).to be false }
+      it { expect(matcher.match?("post.created")).to be true }
     end
 
-    context 'and consist of 3 parts' do
-      let(:pattern) { 'admin.*.created' }
+    context "and consist of 3 parts" do
+      let(:pattern) { "admin.*.created" }
 
-      it { expect(matcher.match?('admin.user.created')).to be true }
-      it { expect(matcher.match?('admin.user.updated')).to be false }
-      it { expect(matcher.match?('admin.post.created')).to be true }
+      it { expect(matcher.match?("admin.user.created")).to be true }
+      it { expect(matcher.match?("admin.user.updated")).to be false }
+      it { expect(matcher.match?("admin.post.created")).to be true }
     end
 
-    context 'and consist of 3 parts' do
-      let(:pattern) { 'admin.user.*' }
+    context "and consist of 3 parts" do
+      let(:pattern) { "admin.user.*" }
 
-      it { expect(matcher.match?('admin.user.created')).to be true }
-      it { expect(matcher.match?('admin.user.updated')).to be true }
-      it { expect(matcher.match?('admin.post.created')).to be false }
-    end
-  end
-
-  context 'when pattern match all' do
-    let(:pattern) { '*' }
-
-    it { expect(matcher.match?('user.created')).to be true }
-    it { expect(matcher.match?('user.updated')).to be true }
-    it { expect(matcher.match?('post.created')).to be true }
-
-    context 'and consist of 3 parts' do
-      let(:pattern) { '*' }
-
-      it { expect(matcher.match?('admin.user.created')).to be true }
-      it { expect(matcher.match?('admin.user.updated')).to be true }
-      it { expect(matcher.match?('admin.post.created')).to be true }
+      it { expect(matcher.match?("admin.user.created")).to be true }
+      it { expect(matcher.match?("admin.user.updated")).to be true }
+      it { expect(matcher.match?("admin.post.created")).to be false }
     end
   end
 
-  context 'when pattern contains invalid chars' do
-    let(:pattern) { 'user.cre*ated' }
+  context "when pattern match all" do
+    let(:pattern) { "*" }
 
-    it { expect(matcher.match?('user.cre*ated')).to be true }
-    it { expect(matcher.match?('user.created')).to be false }
-    it { expect(matcher.match?('user.updated')).to be false }
-    it { expect(matcher.match?('post.created')).to be false }
+    it { expect(matcher.match?("user.created")).to be true }
+    it { expect(matcher.match?("user.updated")).to be true }
+    it { expect(matcher.match?("post.created")).to be true }
+
+    context "and consist of 3 parts" do
+      let(:pattern) { "*" }
+
+      it { expect(matcher.match?("admin.user.created")).to be true }
+      it { expect(matcher.match?("admin.user.updated")).to be true }
+      it { expect(matcher.match?("admin.post.created")).to be true }
+    end
+  end
+
+  context "when pattern contains invalid chars" do
+    let(:pattern) { "user.cre*ated" }
+
+    it { expect(matcher.match?("user.cre*ated")).to be true }
+    it { expect(matcher.match?("user.created")).to be false }
+    it { expect(matcher.match?("user.updated")).to be false }
+    it { expect(matcher.match?("post.created")).to be false }
   end
 end

--- a/spec/unit/hanami/events/mixin_spec.rb
+++ b/spec/unit/hanami/events/mixin_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Events::Mixin do
-  context 'when included into class' do
+  context "when included into class" do
     let(:event_bus) { Hanami::Events.new(:memory_sync) }
 
     subject(:dummy_handler) do
@@ -12,19 +14,19 @@ RSpec.describe Hanami::Events::Mixin do
       end
     end
 
-    it 'calls #call method on subscriber with payload' do
-      dummy_handler.send(:subscribe_to, event_bus, 'user.created')
+    it "calls #call method on subscriber with payload" do
+      dummy_handler.send(:subscribe_to, event_bus, "user.created")
       expect_any_instance_of(dummy_handler).to receive(:call).with(user_id: 1)
 
-      event_bus.broadcast('user.created', user_id: 1)
+      event_bus.broadcast("user.created", user_id: 1)
     end
 
-    context 'with extra arguments' do
-      it 'includes extra args when calling #subscribe on the event bus' do
-        name = 'dummy-handler'
+    context "with extra arguments" do
+      it "includes extra args when calling #subscribe on the event bus" do
+        name = "dummy-handler"
         expect(event_bus).to receive(:subscribe).with(anything, name: name)
 
-        dummy_handler.send(:subscribe_to, event_bus, 'user.created', name: name)
+        dummy_handler.send(:subscribe_to, event_bus, "user.created", name: name)
       end
     end
   end

--- a/spec/unit/hanami/events/runner_spec.rb
+++ b/spec/unit/hanami/events/runner_spec.rb
@@ -1,43 +1,45 @@
-require 'connection_pool'
-require 'redis'
-require 'hanami/events/runner'
+# frozen_string_literal: true
+
+require "connection_pool"
+require "redis"
+require "hanami/events/runner"
 
 RSpec.describe Hanami::Events::Runner do
   let(:event_runner) { described_class.new(event_instance) }
   let(:io) { StringIO.new }
   let(:logger) { Logger.new(io) }
-  let(:redis) { ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: 'localhost', port: 6379) } }
+  let(:redis) { ConnectionPool.new(size: 5, timeout: 5) { Redis.new(host: "localhost", port: 6379) } }
 
   let(:event_instance) { Hanami::Events.new(:redis, redis: redis, logger: logger) }
 
   before do
-    allow(SecureRandom).to receive(:uuid).and_return('abcd1234')
+    allow(SecureRandom).to receive(:uuid).and_return("abcd1234")
 
     $comment_array = []
 
-    event_instance.subscribe('comment.created') do |payload|
+    event_instance.subscribe("comment.created") do |payload|
       $comment_array << payload
     end
 
-    event_instance.subscribe('comment.created') do |payload|
+    event_instance.subscribe("comment.created") do |payload|
       $comment_array << payload
     end
   end
 
-  it 'polls subscribers for event instance' do
-    event_instance.broadcast('comment.created', user_id: 1)
+  it "polls subscribers for event instance" do
+    event_instance.broadcast("comment.created", user_id: 1)
     expect($comment_array).to eq []
     thread = Thread.new { event_runner.start }
 
     sleep 1.1
-    expect($comment_array).to eq [{ 'user_id' => 1 }, { 'user_id' => 1 }]
+    expect($comment_array).to eq [{"user_id" => 1}, {"user_id" => 1}]
     thread.exit
   end
 
-  xcontext 'with real STDOUT' do
+  xcontext "with real STDOUT" do
     let(:io) { STDOUT }
 
-    it 'logs start message' do
+    it "logs start message" do
       expect { event_runner.start }.to output("my message").to_stdout
     end
   end

--- a/spec/unit/hanami/events/serializer/json_spec.rb
+++ b/spec/unit/hanami/events/serializer/json_spec.rb
@@ -1,15 +1,17 @@
-require 'hanami/events/serializer/json'
+# frozen_string_literal: true
+
+require "hanami/events/serializer/json"
 
 RSpec.describe Hanami::Events::Serializer::Json do
   let(:serializer) { described_class.new }
-  let(:event) { { id: 'abcd1234', event_name: 'user.created', payload: { user_id: 1 } } }
+  let(:event) { {id: "abcd1234", event_name: "user.created", payload: {user_id: 1}} }
   let(:event_string) { '{"id":"abcd1234","event_name":"user.created","payload":{"user_id":1}}' }
 
-  describe '#serialize' do
+  describe "#serialize" do
     it { expect { serializer.serialize(event).to eq event_string } }
   end
 
-  describe '#deserialize' do
+  describe "#deserialize" do
     it { expect { serializer.deserialize(event_string).to match event } }
   end
 end

--- a/spec/unit/hanami/events/serializer_spec.rb
+++ b/spec/unit/hanami/events/serializer_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Events::Serializer do
-  describe '.keys' do
-    it { expect(described_class.keys).to include('json') }
+  describe ".keys" do
+    it { expect(described_class.keys).to include("json") }
   end
 
-  describe '.[]' do
+  describe ".[]" do
     it { expect(described_class[:json]).to eq(Hanami::Events::Serializer::Json) }
   end
 end

--- a/spec/unit/hanami/events/subscriber_spec.rb
+++ b/spec/unit/hanami/events/subscriber_spec.rb
@@ -1,58 +1,60 @@
-require 'logger'
+# frozen_string_literal: true
+
+require "logger"
 
 RSpec.describe Hanami::Events::Subscriber do
   let(:block) { proc { |payload| payload } }
-  let(:subscriber) { described_class.new('user.created', block) }
+  let(:subscriber) { described_class.new("user.created", block) }
 
-  describe '#call' do
-    context 'when event name matched' do
-      it 'calls event block' do
-        expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1)
+  describe "#call" do
+    context "when event name matched" do
+      it "calls event block" do
+        expect(subscriber.call("user.created", user_id: 1)).to eq(user_id: 1)
       end
     end
 
-    context 'when event pattern match range' do
+    context "when event pattern match range" do
       let(:subscriber) { described_class.new(/\Auser.*/, block) }
 
-      it { expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('user.deleted', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('post.deleted', post_id: 1)).to eq nil }
+      it { expect(subscriber.call("user.created", user_id: 1)).to eq(user_id: 1) }
+      it { expect(subscriber.call("user.deleted", user_id: 1)).to eq(user_id: 1) }
+      it { expect(subscriber.call("post.deleted", post_id: 1)).to eq nil }
     end
 
-    context 'when event pattern match all' do
-      let(:subscriber) { described_class.new('*', block) }
+    context "when event pattern match all" do
+      let(:subscriber) { described_class.new("*", block) }
 
-      it { expect(subscriber.call('user.created', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('user.deleted', user_id: 1)).to eq(user_id: 1) }
-      it { expect(subscriber.call('post.deleted', post_id: 1)).to eq(post_id: 1) }
+      it { expect(subscriber.call("user.created", user_id: 1)).to eq(user_id: 1) }
+      it { expect(subscriber.call("user.deleted", user_id: 1)).to eq(user_id: 1) }
+      it { expect(subscriber.call("post.deleted", post_id: 1)).to eq(post_id: 1) }
     end
 
-    context 'when event name not matched' do
-      it 'calls nothing' do
-        expect(subscriber.call('user.deleted', user_id: 1)).to eq nil
+    context "when event name not matched" do
+      it "calls nothing" do
+        expect(subscriber.call("user.deleted", user_id: 1)).to eq nil
       end
     end
 
-    context 'with logger' do
-      let(:block) { ->(_payload) { logger.info('in event') } }
+    context "with logger" do
+      let(:block) { ->(_payload) { logger.info("in event") } }
       let(:logger) { Logger.new(StringIO.new) }
-      let(:subscriber) { described_class.new('user.created', block, logger) }
+      let(:subscriber) { described_class.new("user.created", block, logger) }
 
-      it 'calls logger' do
-        expect(logger).to receive(:info).with('in event')
-        subscriber.call('user.created', user_id: 1)
+      it "calls logger" do
+        expect(logger).to receive(:info).with("in event")
+        subscriber.call("user.created", user_id: 1)
       end
     end
 
-    context 'when handler try to call protected objects' do
+    context "when handler try to call protected objects" do
       let(:block) { ->(_payload) { meta } }
-      let(:subscriber) { described_class.new('user.created', block) }
+      let(:subscriber) { described_class.new("user.created", block) }
 
-      it { expect { subscriber.call('user.created', user_id: 1) }.to raise_error(NameError) }
+      it { expect { subscriber.call("user.created", user_id: 1) }.to raise_error(NameError) }
     end
   end
 
-  describe '#meta' do
-    it { expect(subscriber.meta).to eq(name: 'user.created') }
+  describe "#meta" do
+    it { expect(subscriber.meta).to eq(name: "user.created") }
   end
 end

--- a/spec/unit/hanami/events/version_spec.rb
+++ b/spec/unit/hanami/events/version_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Events::VERSION" do
-  it 'exposes version' do
-    expect(Hanami::Events::VERSION).to eq('0.2.1')
+  it "exposes version" do
+    expect(Hanami::Events::VERSION).to eq("0.2.1")
   end
 end

--- a/spec/unit/hanami/events_spec.rb
+++ b/spec/unit/hanami/events_spec.rb
@@ -1,71 +1,73 @@
-require 'support/fixtures'
+# frozen_string_literal: true
+
+require "support/fixtures"
 
 RSpec.describe Hanami::Events do
   let(:event) { Hanami::Events.new(:memory_sync) }
 
   it { expect(event).to be_a(Hanami::Events::Base) }
 
-  context 'with #initialize aliase' do
+  context "with #initialize aliase" do
     it { expect(Hanami::Events.initialize(:memory_sync)).to be_a(Hanami::Events::Base) }
   end
 
-  describe '#adapter' do
+  describe "#adapter" do
     it { expect(event.adapter).to be_a(Hanami::Events::Adapter::MemorySync) }
   end
 
-  describe '#broadcast' do
-    let(:event_name) { 'user.created' }
+  describe "#broadcast" do
+    let(:event_name) { "user.created" }
 
     before do
       event.subscribe(event_name) { |payload| payload }
     end
 
-    it 'calls #broadcast on adapter' do
-      expect(event.adapter).to receive(:broadcast).with('user.created', user_id: 1)
-      event.broadcast('user.created', user_id: 1)
+    it "calls #broadcast on adapter" do
+      expect(event.adapter).to receive(:broadcast).with("user.created", user_id: 1)
+      event.broadcast("user.created", user_id: 1)
     end
   end
 
-  describe '#subscribed_events' do
+  describe "#subscribed_events" do
     before do
-      event.subscribe('user.created') { |payload| payload }
-      event.subscribe('user.updated') { |payload| payload }
+      event.subscribe("user.created") { |payload| payload }
+      event.subscribe("user.updated") { |payload| payload }
       deleted_proc = proc { |payload| payload }
-      event.subscribe('user.deleted', deleted_proc)
+      event.subscribe("user.deleted", deleted_proc)
     end
 
-    it 'returns list of all subscribed events' do
+    it "returns list of all subscribed events" do
       expect(event.subscribed_events).to eq(
         [
-          { name: 'user.created' },
-          { name: 'user.updated' },
-          { name: 'user.deleted' }
+          {name: "user.created"},
+          {name: "user.updated"},
+          {name: "user.deleted"}
         ]
       )
     end
   end
 
-  describe '#subscribe' do
-    it 'pushes subscriber to subscribers list' do
+  describe "#subscribe" do
+    it "pushes subscriber to subscribers list" do
       expect do
-        event.subscribe('event.name') { |payload| payload }
+        event.subscribe("event.name") { |payload| payload }
       end.to change { event.adapter.subscribers.count }.by(1)
     end
   end
 
-  describe '#format' do
+  describe "#format" do
     before do
-      event.subscribe('user.created') { |payload| payload }
-      event.subscribe('user.updated') { |payload| payload }
-      event.subscribe('user.deleted') { |payload| payload }
+      event.subscribe("user.created") { |payload| payload }
+      event.subscribe("user.updated") { |payload| payload }
+      event.subscribe("user.deleted") { |payload| payload }
     end
 
-    it 'returns list of all subscribed events' do
+    it "returns list of all subscribed events" do
       expect(event.format(:json)).to eq "{\"events\":[{\"name\":\"user.created\"},{\"name\":\"user.updated\"},{\"name\":\"user.deleted\"}]}"
     end
   end
 
-  it 'allows to add custom adapters' do
+  it "allows to add custom adapters" do
     Hanami::Events::Adapter.register(:mock_adapter) { MockAdapter }
 
     event = Hanami::Events.new(:mock_adapter)


### PR DESCRIPTION
I cannot run `bundle exec rake` without this fix in Ruby 2.6.6.

```
$ bundle exec rake

An error occurred while loading spec_helper.
Failure/Error: include Concurrent::Async

NameError:
  uninitialized constant Concurrent::Async
# ./lib/hanami/events/runner.rb:5:in `<class:Runner>'
# ./lib/hanami/events/runner.rb:4:in `<module:Events>'
# ./lib/hanami/events/runner.rb:2:in `<module:Hanami>'
# ./lib/hanami/events/runner.rb:1:in `<top (required)>'
# ./lib/hanami/events.rb:9:in `require'
# ./lib/hanami/events.rb:9:in `<top (required)>'
# ./spec/spec_helper.rb:4:in `require'
# ./spec/spec_helper.rb:4:in `<top (required)>'
No examples found.


Finished in 0.00007 seconds (files took 0.68251 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```
